### PR TITLE
Use subscription_type in the production metadata

### DIFF
--- a/src/Handlers/ProcessWebhook.php
+++ b/src/Handlers/ProcessWebhook.php
@@ -114,11 +114,11 @@ class ProcessWebhook extends ProcessWebhookJob
      */
     private function handleSubscriptionCreated(array $payload): void
     {
-        $customerMetadata = $payload['customer']['metadata'];
+        $productMetadata = $payload['product']['metadata'];
         $billable = $this->resolveBillable($payload);
 
         $subscription = $billable->subscriptions()->create([ // @phpstan-ignore-line class.notFound - the property is found in the billable model
-            'type' => $customerMetadata['subscription_type'] ?? 'default',
+            'type' => $productMetadata['subscription_type'] ?? 'default',
             'polar_id' => $payload['id'],
             'status' => $payload['status'],
             'product_id' => $payload['product_id'],


### PR DESCRIPTION
When a subscription is created, it should read subscription_type in the product metadata and save into the database as well. The default value is "default" (string).

For example, if the production subscription_type is `business, `team` or `pro`, it'll be able to call `subscribed` like this.

```php
// if subscription_type is not set
$user->subscribed('default');

// if subscription_type is either business, team or pro
if ($user->subscribed('business')) {
    $max = '5m';
} elseif ($user->subscribed('team')) {
    $max = '3m';
} elseif ($user->subscribed('pro')) {
    $max = '1m';
} else { // free
    $max = '200k';
}


```