### PR TITLE
bug: Fix cancel, resume or swap an active subscription

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -220,7 +220,7 @@ class Subscription extends Model // @phpstan-ignore-line propertyTag.trait - Bil
      */
     public function swap(string $productId, ?ProrationBehavior $prorationBehavior = ProrationBehavior::Prorate): self
     {
-        $response = LaravelPolar::updateSubscription(
+        $data = LaravelPolar::updateSubscription(
             subscriptionId: $this->polar_id,
             request: SubscriptionUpdateProductData::from([
                 'productId' => $productId,
@@ -228,7 +228,7 @@ class Subscription extends Model // @phpstan-ignore-line propertyTag.trait - Bil
             ]),
         );
 
-        $this->sync((array) $response);
+        $this->sync($data->toArray());
 
         return $this;
     }
@@ -246,12 +246,12 @@ class Subscription extends Model // @phpstan-ignore-line propertyTag.trait - Bil
      */
     public function cancel(): self
     {
-        $response = LaravelPolar::updateSubscription(
+        $data = LaravelPolar::updateSubscription(
             subscriptionId: $this->polar_id,
             request: SubscriptionCancelData::from(['cancelAtPeriodEnd' => true]),
         );
 
-        $this->sync((array) $response);
+        $this->sync($data->toArray());
 
         return $this;
     }
@@ -265,12 +265,12 @@ class Subscription extends Model // @phpstan-ignore-line propertyTag.trait - Bil
             throw new PolarApiError('Subscription is incomplete and expired.');
         }
 
-        $response = LaravelPolar::updateSubscription(
+        $data = LaravelPolar::updateSubscription(
             subscriptionId: $this->polar_id,
             request: SubscriptionCancelData::from(['cancelAtPeriodEnd' => false]),
         );
 
-        $this->sync((array) $response);
+        $this->sync($data->toArray());
 
         return $this;
     }


### PR DESCRIPTION
The "(array) $response" cast results an array with properties in camel-case style because it is an instance of `Spatie\LaravelData\Data`. 

- "status" is ok because it is single word.
- "current_period_end" and "ends_at" are always set as null because they must be accessed via `$attributes["currentPeriodEnd"]` and `$attributes['endsAt']`
- "product_id" must be accessed via `$attributes["product_id"]`, so it raises an error.

```
   /**
     * Sync the subscription with the given attributes.
     *
     * @param  array<string, mixed>  $attributes
     */
    public function sync(array $attributes): self
    {
        $this->update([
            'status' => $attributes['status'],
            'product_id' => $attributes['product_id'],
            'current_period_end' => isset($attributes['current_period_end']) ? Carbon::make($attributes['current_period_end']) : null,
            'ends_at' => isset($attributes['ends_at']) ? Carbon::make($attributes['ends_at']) : null,
        ]);

        return $this;
    }
```

Therefore, we have to pass `$response->toArray()` into the Subscription sync method. It's similar to other places such as webhook handler.

resolved https://github.com/danestves/laravel-polar/issues/32